### PR TITLE
Migrated setup.py to setuptools. Added dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='asterix',
       version='0.3',
@@ -38,4 +38,10 @@ All modules are platform independent, working with Python 2.7
 
 All modules rely on pyscard, a package implementing PCSC layer
 for communication with smartcards.
-""", )
+""",
+      install_requires=[
+        "pyscard>=1.6.16",
+        "pycrypto>=2.6.1",
+        "ecdsa>= 0.11",
+      ],
+)


### PR DESCRIPTION
This improvements for setup.py allows automatic installation of dependencies via pip:

``` 
fontanon@ama-gi:~/$ virtualenv testasterix
New python executable in /home/fontanon/testasterix/bin/python
Installing setuptools, pip, wheel...done.
fontanon@ama-gi:~/$ source testasterix/bin/activate
(testasterix) fontanon@ama-gi:~/$ cd
(testasterix) fontanon@ama-gi:~$ cd asterix/
(testasterix) fontanon@ama-gi:~/asterix$ ls
asterix  LICENSE  MANIFEST.in  README.md  setup.py
(testasterix) fontanon@ama-gi:~/asterix$ python setup.py install
running install
running bdist_egg
running egg_info
creating asterix.egg-info
writing requirements to asterix.egg-info/requires.txt
writing asterix.egg-info/PKG-INFO
writing top-level names to asterix.egg-info/top_level.txt
writing dependency_links to asterix.egg-info/dependency_links.txt
writing manifest file 'asterix.egg-info/SOURCES.txt'
reading manifest file 'asterix.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'asterix.egg-info/SOURCES.txt'
installing library code to build/bdist.linux-x86_64/egg
running install_lib
running build_py
creating build
creating build/lib.linux-x86_64-2.7
creating build/lib.linux-x86_64-2.7/asterix
copying asterix/APDU.py -> build/lib.linux-x86_64-2.7/asterix
copying asterix/formutil.py -> build/lib.linux-x86_64-2.7/asterix
copying asterix/SecurePacket.py -> build/lib.linux-x86_64-2.7/asterix
copying asterix/auth3G.py -> build/lib.linux-x86_64-2.7/asterix
copying asterix/CAT.py -> build/lib.linux-x86_64-2.7/asterix
copying asterix/GAF.py -> build/lib.linux-x86_64-2.7/asterix
copying asterix/__init__.py -> build/lib.linux-x86_64-2.7/asterix
copying asterix/SCP02.py -> build/lib.linux-x86_64-2.7/asterix
copying asterix/SCP03.py -> build/lib.linux-x86_64-2.7/asterix
copying asterix/mycard.py -> build/lib.linux-x86_64-2.7/asterix
copying asterix/applet.py -> build/lib.linux-x86_64-2.7/asterix
creating build/bdist.linux-x86_64
creating build/bdist.linux-x86_64/egg
creating build/bdist.linux-x86_64/egg/asterix
copying build/lib.linux-x86_64-2.7/asterix/APDU.py -> build/bdist.linux-x86_64/egg/asterix
copying build/lib.linux-x86_64-2.7/asterix/formutil.py -> build/bdist.linux-x86_64/egg/asterix
copying build/lib.linux-x86_64-2.7/asterix/SecurePacket.py -> build/bdist.linux-x86_64/egg/asterix
copying build/lib.linux-x86_64-2.7/asterix/auth3G.py -> build/bdist.linux-x86_64/egg/asterix
copying build/lib.linux-x86_64-2.7/asterix/CAT.py -> build/bdist.linux-x86_64/egg/asterix
copying build/lib.linux-x86_64-2.7/asterix/GAF.py -> build/bdist.linux-x86_64/egg/asterix
copying build/lib.linux-x86_64-2.7/asterix/__init__.py -> build/bdist.linux-x86_64/egg/asterix
copying build/lib.linux-x86_64-2.7/asterix/SCP02.py -> build/bdist.linux-x86_64/egg/asterix
copying build/lib.linux-x86_64-2.7/asterix/SCP03.py -> build/bdist.linux-x86_64/egg/asterix
copying build/lib.linux-x86_64-2.7/asterix/mycard.py -> build/bdist.linux-x86_64/egg/asterix
copying build/lib.linux-x86_64-2.7/asterix/applet.py -> build/bdist.linux-x86_64/egg/asterix
byte-compiling build/bdist.linux-x86_64/egg/asterix/APDU.py to APDU.pyc
byte-compiling build/bdist.linux-x86_64/egg/asterix/formutil.py to formutil.pyc
byte-compiling build/bdist.linux-x86_64/egg/asterix/SecurePacket.py to SecurePacket.pyc
byte-compiling build/bdist.linux-x86_64/egg/asterix/auth3G.py to auth3G.pyc
byte-compiling build/bdist.linux-x86_64/egg/asterix/CAT.py to CAT.pyc
byte-compiling build/bdist.linux-x86_64/egg/asterix/GAF.py to GAF.pyc
byte-compiling build/bdist.linux-x86_64/egg/asterix/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-x86_64/egg/asterix/SCP02.py to SCP02.pyc
byte-compiling build/bdist.linux-x86_64/egg/asterix/SCP03.py to SCP03.pyc
byte-compiling build/bdist.linux-x86_64/egg/asterix/mycard.py to mycard.pyc
byte-compiling build/bdist.linux-x86_64/egg/asterix/applet.py to applet.pyc
creating build/bdist.linux-x86_64/egg/EGG-INFO
copying asterix.egg-info/PKG-INFO -> build/bdist.linux-x86_64/egg/EGG-INFO
copying asterix.egg-info/SOURCES.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying asterix.egg-info/dependency_links.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying asterix.egg-info/requires.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying asterix.egg-info/top_level.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
zip_safe flag not set; analyzing archive contents...
creating dist
creating 'dist/asterix-0.3-py2.7.egg' and adding 'build/bdist.linux-x86_64/egg' to it
removing 'build/bdist.linux-x86_64/egg' (and everything under it)
Processing asterix-0.3-py2.7.egg
Copying asterix-0.3-py2.7.egg to /home/fontanon/testasterix/lib/python2.7/site-packages
Adding asterix 0.3 to easy-install.pth file

Installed /home/fontanon/testasterix/lib/python2.7/site-packages/asterix-0.3-py2.7.egg
Processing dependencies for asterix==0.3
Searching for ecdsa>=0.11
Reading https://pypi.org/simple/ecdsa/
Downloading https://files.pythonhosted.org/packages/63/f4/73669d51825516ce8c43b816c0a6b64cd6eb71d08b99820c00792cb42222/ecdsa-0.13-py2.py3-none-any.whl#sha256=40d002cf360d0e035cf2cb985e1308d41aaa087cbfc135b2dc2d844296ea546c
Best match: ecdsa 0.13
Processing ecdsa-0.13-py2.py3-none-any.whl
Installing ecdsa-0.13-py2.py3-none-any.whl to /home/fontanon/testasterix/lib/python2.7/site-packages
Adding ecdsa 0.13 to easy-install.pth file

Installed /home/fontanon/testasterix/lib/python2.7/site-packages/ecdsa-0.13-py2.7.egg
Searching for pycrypto>=2.6.1
Reading https://pypi.org/simple/pycrypto/
Downloading https://files.pythonhosted.org/packages/60/db/645aa9af249f059cc3a368b118de33889219e0362141e75d4eaf6f80f163/pycrypto-2.6.1.tar.gz#sha256=f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c
Best match: pycrypto 2.6.1
Processing pycrypto-2.6.1.tar.gz
Writing /tmp/easy_install-SywdbQ/pycrypto-2.6.1/setup.cfg
Running pycrypto-2.6.1/setup.py -q bdist_egg --dist-dir /tmp/easy_install-SywdbQ/pycrypto-2.6.1/egg-dist-tmp-2sEDNQ
src/MD2.c:44:19: warning: ‘md2_oid’ defined but not used [-Wunused-const-variable=]
 static const char md2_oid[] = { 0x06, 0x08, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x02, 0x02 };
                   ^~~~~~~
In file included from src/SHA256.c:72:0:
src/hash_SHA2_template.c: In function ‘add_length’:
src/hash_SHA2_template.c:97:30: warning: self-comparison always evaluates to false [-Wtautological-compare]
         if (hs->length_upper > hs->length_upper)
                              ^
In file included from src/SHA224.c:73:0:
src/hash_SHA2_template.c: In function ‘add_length’:
src/hash_SHA2_template.c:97:30: warning: self-comparison always evaluates to false [-Wtautological-compare]
         if (hs->length_upper > hs->length_upper)
                              ^
In file included from src/SHA384.c:80:0:
src/hash_SHA2_template.c: In function ‘add_length’:
src/hash_SHA2_template.c:97:30: warning: self-comparison always evaluates to false [-Wtautological-compare]
         if (hs->length_upper > hs->length_upper)
                              ^
In file included from src/SHA512.c:80:0:
src/hash_SHA2_template.c: In function ‘add_length’:
src/hash_SHA2_template.c:97:30: warning: self-comparison always evaluates to false [-Wtautological-compare]
         if (hs->length_upper > hs->length_upper)
                              ^
src/strxor.c:31:19: warning: ‘rcsid’ defined but not used [-Wunused-const-variable=]
 static const char rcsid[] = "$Id$";
                   ^~~~~
src/_counter.c: In function ‘init_counter’:
src/_counter.c:576:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
     if (m == NULL)
     ^~
src/_counter.c:579:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  my_CounterLEType.ob_type = &PyType_Type;
  ^~~~~~~~~~~~~~~~
zip_safe flag not set; analyzing archive contents...
Moving pycrypto-2.6.1-py2.7-linux-x86_64.egg to /home/fontanon/testasterix/lib/python2.7/site-packages
Adding pycrypto 2.6.1 to easy-install.pth file

Installed /home/fontanon/testasterix/lib/python2.7/site-packages/pycrypto-2.6.1-py2.7-linux-x86_64.egg
Searching for pyscard>=1.6.16
Reading https://pypi.org/simple/pyscard/
Downloading https://files.pythonhosted.org/packages/17/f3/e6e52e3dab39b26450d9fb6385c4a40f883180d6f1ee26ad4567dd243edc/pyscard-1.9.7.tar.gz#sha256=412c74c83e7401566e9d3d7b8b5ca965e74582a1f33179b3c1fabf1da73ebf80
Best match: pyscard 1.9.7
Processing pyscard-1.9.7.tar.gz
Writing /tmp/easy_install-P88RvL/pyscard-1.9.7/setup.cfg
Running pyscard-1.9.7/setup.py -q bdist_egg --dist-dir /tmp/easy_install-P88RvL/pyscard-1.9.7/egg-dist-tmp-YHzkiA
warning: no files found matching 'README'
warning: no files found matching '*.html' under directory 'smartcard/doc'
warning: no files found matching '*.css' under directory 'smartcard/doc'
warning: no files found matching '*.js' under directory 'smartcard/doc'
warning: no files found matching '*.txt' under directory 'smartcard/doc'
In file included from smartcard/scard/scard_wrap.c:3062:0:
smartcard/scard/scard_wrap.c: In function ‘_wrap_SCardGetAttrib’:
smartcard/scard/memlog.h:50:26: warning: attempt to free a non-heap object ‘temp3’ [-Wfree-nonheap-object]
         #define mem_Free free
smartcard/scard/scard_wrap.c:4089:9: note: in expansion of macro ‘mem_Free’
         mem_Free( arg3 );
         ^~~~~~~~
smartcard/scard/memlog.h:50:26: warning: attempt to free a non-heap object ‘temp3’ [-Wfree-nonheap-object]
         #define mem_Free free
smartcard/scard/scard_wrap.c:4104:9: note: in expansion of macro ‘mem_Free’
         mem_Free( arg3 );
         ^~~~~~~~
smartcard/scard/scard_wrap.c: In function ‘_wrap_SCardTransmit’:
smartcard/scard/memlog.h:50:26: warning: attempt to free a non-heap object ‘temp4’ [-Wfree-nonheap-object]
         #define mem_Free free
smartcard/scard/scard_wrap.c:5106:9: note: in expansion of macro ‘mem_Free’
         mem_Free( arg4 );
         ^~~~~~~~
smartcard/scard/memlog.h:50:26: warning: attempt to free a non-heap object ‘temp4’ [-Wfree-nonheap-object]
         #define mem_Free free
smartcard/scard/scard_wrap.c:5134:9: note: in expansion of macro ‘mem_Free’
         mem_Free( arg4 );
         ^~~~~~~~
smartcard/scard/scard_wrap.c: In function ‘_wrap_SCardStatus’:
smartcard/scard/memlog.h:50:26: warning: attempt to free a non-heap object ‘temp5’ [-Wfree-nonheap-object]
         #define mem_Free free
smartcard/scard/scard_wrap.c:4994:9: note: in expansion of macro ‘mem_Free’
         mem_Free( arg5 );
         ^~~~~~~~
smartcard/scard/memlog.h:50:26: warning: attempt to free a non-heap object ‘temp5’ [-Wfree-nonheap-object]
         #define mem_Free free
smartcard/scard/scard_wrap.c:5030:9: note: in expansion of macro ‘mem_Free’
         mem_Free( arg5 );
         ^~~~~~~~
smartcard/scard/scard_wrap.c: In function ‘_wrap_SCardListReaderGroups’:
smartcard/scard/memlog.h:50:26: warning: attempt to free a non-heap object ‘temp2’ [-Wfree-nonheap-object]
         #define mem_Free free
smartcard/scard/scard_wrap.c:4791:9: note: in expansion of macro ‘mem_Free’
         mem_Free( arg2 );
         ^~~~~~~~
smartcard/scard/memlog.h:50:26: warning: attempt to free a non-heap object ‘temp2’ [-Wfree-nonheap-object]
         #define mem_Free free
smartcard/scard/scard_wrap.c:4820:9: note: in expansion of macro ‘mem_Free’
         mem_Free( arg2 );
         ^~~~~~~~
smartcard/scard/scard_wrap.c: In function ‘_wrap_SCardListReaders’:
smartcard/scard/memlog.h:50:26: warning: attempt to free a non-heap object ‘temp3’ [-Wfree-nonheap-object]
         #define mem_Free free
smartcard/scard/scard_wrap.c:4675:9: note: in expansion of macro ‘mem_Free’
         mem_Free( arg3 );
         ^~~~~~~~
smartcard/scard/memlog.h:50:26: warning: attempt to free a non-heap object ‘temp3’ [-Wfree-nonheap-object]
         #define mem_Free free
smartcard/scard/scard_wrap.c:4731:9: note: in expansion of macro ‘mem_Free’
         mem_Free( arg3 );
         ^~~~~~~~
smartcard/scard/scard_wrap.c: In function ‘_wrap_SCardControl’:
smartcard/scard/memlog.h:50:26: warning: attempt to free a non-heap object ‘temp4’ [-Wfree-nonheap-object]
         #define mem_Free free
smartcard/scard/scard_wrap.c:4244:9: note: in expansion of macro ‘mem_Free’
         mem_Free( arg4 );
         ^~~~~~~~
smartcard/scard/memlog.h:50:26: warning: attempt to free a non-heap object ‘temp4’ [-Wfree-nonheap-object]
         #define mem_Free free
smartcard/scard/scard_wrap.c:4272:9: note: in expansion of macro ‘mem_Free’
         mem_Free( arg4 );
         ^~~~~~~~
zip_safe flag not set; analyzing archive contents...
smartcard.scard.scard: module references __file__
smartcard.wx.__init__: module references __file__
creating /home/fontanon/testasterix/lib/python2.7/site-packages/pyscard-1.9.7-py2.7-linux-x86_64.egg
Extracting pyscard-1.9.7-py2.7-linux-x86_64.egg to /home/fontanon/testasterix/lib/python2.7/site-packages
Adding pyscard 1.9.7 to easy-install.pth file

Installed /home/fontanon/testasterix/lib/python2.7/site-packages/pyscard-1.9.7-py2.7-linux-x86_64.egg
Finished processing dependencies for asterix==0.3
```